### PR TITLE
ダミーデータ生成スクリプトを作成

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.py[cod]
+
+data

--- a/backend/app/scripts/generate_airport_master.py
+++ b/backend/app/scripts/generate_airport_master.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import os
+
+# 保存先ディレクトリ
+data_dir = "../data"
+os.makedirs(data_dir, exist_ok=True)
+
+# 空港マスタ用リスト（20件）
+airport_list = [
+  {"code": "HND", "name": "Tokyo Haneda", "region": "Kanto", "scale": "hub", "lat": 35.553333, "lon": 139.781113},
+  {"code": "NRT", "name": "Narita", "region": "Kanto", "scale": "hub", "lat": 35.769272, "lon": 140.389898},
+  {"code": "ITM", "name": "Osaka Itami", "region": "Kansai", "scale": "regional", "lat": 34.7840, "lon": 135.4368},
+  {"code": "KIX", "name": "Kansai Intl", "region": "Kansai", "scale": "hub", "lat": 34.427299, "lon": 135.244003},
+  {"code": "CTS", "name": "New Chitose", "region": "Hokkaido", "scale": "hub", "lat": 42.7718, "lon": 141.6888},
+  {"code": "OKA", "name": "Naha", "region": "Okinawa", "scale": "hub", "lat": 26.1966997, "lon": 127.648952},
+  {"code": "FUK", "name": "Fukuoka", "region": "Kyushu", "scale": "hub", "lat": 33.5840, "lon": 130.4510},
+  {"code": "NGO", "name": "Chubu Centrair", "region": "Chubu", "scale": "hub", "lat": 34.858334, "lon": 136.805283},
+  {"code": "SDJ", "name": "Sendai", "region": "Tohoku", "scale": "regional", "lat": 38.1375, "lon": 140.9186},
+  {"code": "AOJ", "name": "Aomori", "region": "Tohoku", "scale": "regional", "lat": 40.7375, "lon": 140.7392},
+  {"code": "AKJ", "name": "Asahikawa", "region": "Hokkaido", "scale": "regional", "lat": 43.7700, "lon": 142.3656},
+  {"code": "HIJ", "name": "Hiroshima", "region": "Chugoku", "scale": "regional", "lat": 34.4340, "lon": 132.9195},
+  {"code": "OKJ", "name": "Okayama", "region": "Chugoku", "scale": "regional", "lat": 34.8019, "lon": 133.9347},
+  {"code": "MYJ", "name": "Matsuyama", "region": "Shikoku", "scale": "regional", "lat": 33.8392, "lon": 132.7653},
+  {"code": "TAK", "name": "Takamatsu", "region": "Shikoku", "scale": "regional", "lat": 34.1850, "lon": 134.0433},
+  {"code": "KOJ", "name": "Kagoshima", "region": "Kyushu", "scale": "regional", "lat": 31.8036, "lon": 130.7181},
+  {"code": "KMI", "name": "Miyazaki", "region": "Kyushu", "scale": "regional", "lat": 31.9111, "lon": 131.4450},
+  {"code": "ISG", "name": "Ishigaki", "region": "Okinawa", "scale": "regional", "lat": 24.3442, "lon": 124.1897},
+  {"code": "SHM", "name": "Shimojishima", "region": "Okinawa", "scale": "regional", "lat": 24.8050, "lon": 124.1850},
+  {"code": "OIT", "name": "Oita", "region": "Kyushu", "scale": "regional", "lat": 33.0800, "lon": 131.7194}
+]
+
+# DataFrame に変換
+airport_master = pd.DataFrame(airport_list)
+
+# CSVに保存
+airport_master.to_csv(f"{data_dir}/airport_master.csv", index=False)
+
+print("data/ に airport_master.csv を生成しました。")

--- a/backend/app/scripts/generate_flight_history.py
+++ b/backend/app/scripts/generate_flight_history.py
@@ -1,0 +1,99 @@
+import pandas as pd
+import numpy as np
+import os
+from datetime import datetime, timedelta
+
+# 保存先ディレクトリ
+data_dir = "../data"
+os.makedirs(data_dir, exist_ok=True)
+
+# 便マスタ読み込み
+flight_master = pd.read_csv(f"{data_dir}/flight_master.csv")
+airport_master = pd.read_csv(f"{data_dir}/airport_master.csv")
+
+# 日付範囲
+start_date = datetime(2024, 1, 1)
+end_date = datetime(2024, 12, 31)
+dates = pd.date_range(start_date, end_date)
+
+# 祝日フラグ（元旦・GW・お盆・年末年始など適当に設定）
+holidays = [
+  "2024-01-01", "2024-01-02", "2024-01-03", "2024-01-08", "2024-02-11",
+  "2024-02-12", "2024-02-23", "2024-03-20", "2024-04-29", "2024-04-30",
+  "2024-05-01", "2024-05-02", "2024-05-03", "2024-05-04", "2024-05-05",
+  "2024-05-06", "2024-07-15", "2024-08-11", "2024-08-12", "2024-08-13",
+  "2024-08-14", "2024-08-15", "2024-09-16", "2024-09-22", "2024-09-23",
+  "2024-10-14", "2024-11-03", "2024-11-04", "2024-11-23", "2024-12-29",
+  "2024-12-30", "2024-12-31"
+]
+
+# 天候フラグ（0:通常, 1:悪天候）をランダムで設定
+np.random.seed(42)
+
+records = []
+
+for _, flight in flight_master.iterrows():
+  dep_airport = airport_master[airport_master['code'] == flight['departure']].iloc[0]
+  arr_airport = airport_master[airport_master['code'] == flight['arrival']].iloc[0]
+
+  # hub判定（出発空港または到着空港が hub かどうか）
+  is_hub = (dep_airport['scale'] == 'hub') or (arr_airport['scale'] == 'hub')
+
+  for date in dates:
+    month = date.month
+    weekday = date.weekday()
+    holiday_flag = int(date.strftime("%Y-%m-%d") in holidays)
+    weekend_flag = int(weekday >= 5)
+    weather_flag = np.random.choice([0,1], p=[0.9,0.1])  # 10%の悪天候
+
+    # base_demand は内部計算用
+    base_demand = 50  # 基本値
+    if is_hub:
+      base_demand += 50  # hub便は需要高め
+    if flight['distance_cat'] == "medium":
+      base_demand += 10
+    elif flight['distance_cat'] == "long":
+      base_demand += 20
+    if weekend_flag:
+      base_demand += 5
+    if holiday_flag:
+      base_demand += 10
+    if weather_flag == 1:
+      base_demand -= 10  # 悪天候で減少
+
+    # 予約者数
+    reservations = int(base_demand * np.random.uniform(0.7, 0.95))
+    # 搭乗者数
+    passengers = int(reservations * np.random.uniform(0.9,1.0))
+    # 搭乗率
+    load_factor = round(passengers / flight['seat_capacity'], 3)
+
+    records.append({
+      "flight_no": flight['flight_no'],
+      "date": date.strftime("%Y-%m-%d"),
+      "month": month,
+      "weekday": weekday,
+      "holiday_flag": holiday_flag,
+      "weather_flag": weather_flag,
+      "reservations": reservations,
+      "passengers": passengers,
+      "seat_capacity": flight['seat_capacity'],
+      "load_factor": load_factor
+    })
+
+# DataFrame化
+df = pd.DataFrame(records)
+
+# n日前の搭乗者数ラグ作成
+df = df.sort_values(['flight_no','date'])
+for lag in [7,14,30]:
+  lag_col = f'lag_{lag}'
+  df[lag_col] = df.groupby('flight_no')['passengers'].shift(lag)
+
+  # ラグが存在しない最初の数日だけ便ごとの平均で補完
+  df[lag_col] = df.groupby('flight_no')[lag_col].transform(lambda x: x.fillna(x.mean()))
+
+# CSV出力
+df.to_csv(f"{data_dir}/flight_history.csv", index=False)
+
+print("data/ に flight_history.csv を生成しました。")

--- a/backend/app/scripts/generate_flight_master.py
+++ b/backend/app/scripts/generate_flight_master.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import numpy as np
+import os
+from itertools import count
+
+# 距離計算用の関数を用意
+def haversine(lat1, lon1, lat2, lon2):
+  """2地点の距離（km）を計算"""
+  R = 6371  # 地球半径 (km)
+  phi1, phi2 = np.radians(lat1), np.radians(lat2)
+  dphi = phi2 - phi1
+  dlambda = np.radians(lon2 - lon1)
+  a = np.sin(dphi/2)**2 + np.cos(phi1)*np.cos(phi2)*np.sin(dlambda/2)**2
+  return 2 * R * np.arcsin(np.sqrt(a))
+
+def get_distance_category(distance_km):
+  """距離カテゴリを自動判定"""
+  if distance_km <= 500:
+    return "short"
+  elif distance_km <= 1500:
+    return "medium"
+  else:
+    return "long"
+
+def get_seat_capacity(distance_cat):
+  """距離カテゴリに応じた座席数を設定"""
+  if distance_cat == "short":
+    return np.random.choice([60, 70, 80, 90])
+  elif distance_cat == "medium":
+    return np.random.choice([100, 120, 140, 150])
+  else:
+    return np.random.choice([180, 200, 220, 240])
+
+# 保存先ディレクトリ
+data_dir = "../data"
+os.makedirs(data_dir, exist_ok=True)
+
+# 空港マスタ読み込み
+airport_master = pd.read_csv(f"{data_dir}/airport_master.csv")
+
+# 全空港ペア作成（同じ空港・同じ地域は除外）
+routes = airport_master.merge(
+  airport_master, how='cross', suffixes=('_dep', '_arr')
+)
+routes = routes[
+  (routes['code_dep'] != routes['code_arr']) &
+  (routes['region_dep'] != routes['region_arr'])
+]
+possible_routes = list(routes[['code_dep', 'code_arr']].itertuples(index=False, name=None))
+
+# ランダムに50路線選択
+np.random.seed(42)
+selected_indices = np.random.choice(len(possible_routes), size=50, replace=False)
+selected_routes = [possible_routes[i] for i in selected_indices]
+
+# 便番号生成＆距離カテゴリ判定
+flight_master_records = []
+flight_counter = count(101)
+airline_codes = ["NH", "JL", "BC", "7G", "6J"]
+
+for dep, arr in selected_routes:
+  airline_code = np.random.choice(airline_codes)
+  flight_no = f"{airline_code}{next(flight_counter)}"
+
+  # 出発・到着空港の緯度経度取得
+  dep_row = airport_master[airport_master['code'] == dep].iloc[0]
+  arr_row = airport_master[airport_master['code'] == arr].iloc[0]
+  distance_km = haversine(dep_row['lat'], dep_row['lon'], arr_row['lat'], arr_row['lon'])
+  distance_cat = get_distance_category(distance_km)
+  seat_capacity = get_seat_capacity(distance_cat)
+
+  flight_master_records.append({
+    "flight_no": flight_no,
+    "departure": dep,
+    "arrival": arr,
+    "airline_code": airline_code,
+    "distance_km": round(distance_km, 1),
+    "distance_cat": distance_cat,
+    "seat_capacity": seat_capacity
+  })
+
+# DataFrame に変換
+flight_master = pd.DataFrame(flight_master_records)
+
+# CSVに保存
+flight_master.to_csv(f"{data_dir}/flight_master.csv", index=False)
+
+print("data/ に flight_master.csv を生成しました。")


### PR DESCRIPTION
## 概要
航空需要予測プロジェクトで使用するサンプルデータを自動生成するためのスクリプトを追加。

## 内容

- スクリプト追加
  - `scripts/create_airport_master.py`
    - 適当な国内主要空港20件のマスタデータを生成（空港コード・名称・地域・座標など）

- `scripts/create_flight_master.py`
  - 空港（departure / arrival）ペアからランダムに50路線を生成
  - 距離計算（haversine）に基づき、`short/medium/long` カテゴリを自動判定
  - 航空会社コード (`NH, JL, BC, 7G, 6J`) を付与
  - 各便の座席数を設定

- `scripts/create_flight_history.py`
  - 2024/1/1～2024/12/31 の1年分のフライト履歴を生成
  - 搭乗者数は以下を反映
    - ハブ空港発着の需要増
    - 季節性（夏・年末に増加）
    - 曜日効果（週末需要増）
  - 過去 7日・14日・30日搭乗者数のラグ特徴量を追加
  - ラグが計算できない初期値は便ごとの平均で補完

- 出力される CSV
  - `data/airport_master.csv`
  - `data/flight_master.csv`
  - `data/flight_history.csv`

## 実行方法
```
cd backend/scripts

# 空港マスタ生成
python create_airport_master.py

# 便マスタ生成
python create_flight_master.py

# フライト履歴データ生成
python create_flight_history.py
```

## 備考
- `data/flight_history.csv` に 50便 × 365日 ≒ 18,250件 の履歴データが生成されることを確認

close #1 