### PR TITLE
passenger予測APIの作成

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,9 @@
 from fastapi import FastAPI
 from routers.health import router as health_router
+from routers.predict_passengers import router as predict_passengers_router
 
 app = FastAPI()
+
+# router の登録
 app.include_router(health_router)
+app.include_router(predict_passengers_router)

--- a/backend/app/routers/predict_passengers.py
+++ b/backend/app/routers/predict_passengers.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter
+import pickle
+import pandas as pd
+from pathlib import Path
+from pydantic import BaseModel, conint
+
+router = APIRouter(tags=["prediction"])
+
+# モデルロード（初回のみ）
+MODEL_PATH = Path(__file__).resolve().parent.parent / "data" / "demand_model.pkl"
+with open(MODEL_PATH, "rb") as f:
+  model = pickle.load(f)
+
+class Features(BaseModel):
+  month: conint(ge=1, le=12)
+  weekday: conint(ge=0, le=6)
+  holiday_flag: conint(ge=0, le=1)
+  weather_flag: conint(ge=0, le=1)
+  reservations: int
+  lag_7: float
+  lag_14: float
+  lag_30: float
+
+@router.post("/predict/passengers")
+def predict_passengers(features: Features):
+  """
+  features: JSON形式で特徴量を受け取る
+  """
+
+  # Pydanticモデルから dict に変換して DataFrame に渡す
+  df = pd.DataFrame([features.dict()])
+
+  # 予測
+  pred = model.predict(df)
+
+  return {
+    "features": features.dict(),
+    "prediction": float(pred[0])
+  }


### PR DESCRIPTION
## 概要
学習済み `passengers` モデルをロードして予測値を算出するAPIを作成。

## 変更内容
- `passengers` 予測API
  - エンドポイント: `POST /predict/passengers`
  - JSON 形式で特徴量を受け取り、`passengers` 予測値を返却
  - 返却値例:
      ```
      {
        "features": {
          "month": 1,
          "weekday": 6,
          "holiday_flag": 1,
          "weather_flag": 1,
          "reservations": 200,
          "lag_7": 120,
          "lag_14": 90,
          "lag_30": 181
        },
        "prediction": 121.97042083740234
      }
     ```

## 備考
出発地・到着地・日付などから需要予測を返す機能は未実装のため、`load_factor` モデルの作成・API予測は今後実装。

close #3